### PR TITLE
Add physical memories' boundaries for uVisor

### DIFF
--- a/ld/K64FN1M0xxx12.ld
+++ b/ld/K64FN1M0xxx12.ld
@@ -235,4 +235,10 @@ SECTIONS
     PROVIDE(__heap_size = SIZEOF(.heap));
     PROVIDE(__mbed_sbrk_start = ADDR(.heap));
     PROVIDE(__mbed_krbs_start = ADDR(.heap) + SIZEOF(.heap));
+
+    /* Provide physical memory boundaries for uVisor. */
+    __uvisor_flash_start = ORIGIN(VECTORS);
+    __uvisor_flash_end = ORIGIN(FLASH) + LENGTH(FLASH);
+    __uvisor_sram_start = ORIGIN(RAM) - 0x200;
+    __uvisor_sram_end = ORIGIN(RAM) + LENGTH(RAM);
 }


### PR DESCRIPTION
uVisor runs sanity checks at boot time to verify that its binary blob has been
placed correctly in memory. The symbols provided here are verified against
hard-coded uVisor values.

@autopulated @bogdanm 
